### PR TITLE
fix: parse sheetIndex from URL query params in editorViewModel

### DIFF
--- a/src/renderer/viewmodels/editorViewModel.js
+++ b/src/renderer/viewmodels/editorViewModel.js
@@ -6,6 +6,9 @@ const dataDirectory = path.join(appRoot, 'data');
 const configPath = path.join(appRoot, 'config', 'config.json');
 
 document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(window.location.search);
+    const sheetIndex = params.get('sheetIndex');
+
     let currentActiveGrid = null;
     const keyboardKeys = document.querySelectorAll('#keyboard td');
     let gridBoxes;

--- a/src/renderer/views/editor.html
+++ b/src/renderer/views/editor.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <title>Sheet Editor (beta)</title>
@@ -8,6 +9,7 @@
     <link rel="stylesheet" href="../assets/styles/global.css">
     <link rel="stylesheet" href="../assets/styles/editor.css">
 </head>
+
 <body>
     <div class="editor-container">
         <div class="music-grid">
@@ -69,4 +71,5 @@
     <script type="text/javascript" src="../assets/scripts/notie.js"></script>
     <script src="../viewmodels/editorViewModel.js"></script>
 </body>
+
 </html>


### PR DESCRIPTION
accidentally delete parse sheetIndex from URL query params from editorViewModel reimplemented it 